### PR TITLE
feat: sync gap detection — identify missing transcript and event sequences

### DIFF
--- a/amplifier_session_storage/__init__.py
+++ b/amplifier_session_storage/__init__.py
@@ -61,6 +61,16 @@ from .backends import (
     TranscriptSearchOptions,
 )
 
+# Sync gap detection
+from .backends.base import SyncGapResult
+from .id_utils import (
+    event_id,
+    find_missing_sequences,
+    parse_event_sequence,
+    parse_transcript_sequence,
+    transcript_id,
+)
+
 # Embedding providers
 from .embeddings import EmbeddingCache, EmbeddingProvider
 
@@ -131,6 +141,13 @@ __all__ = [
     "SearchResult",
     "TranscriptSearchOptions",
     "EventSearchOptions",
+    # Sync gap detection
+    "SyncGapResult",
+    "transcript_id",
+    "event_id",
+    "parse_transcript_sequence",
+    "parse_event_sequence",
+    "find_missing_sequences",
     # Embeddings
     "EmbeddingProvider",
     "EmbeddingCache",

--- a/amplifier_session_storage/backends/base.py
+++ b/amplifier_session_storage/backends/base.py
@@ -181,6 +181,21 @@ class SessionSyncStats:
 
 
 @dataclass
+class SyncGapResult:
+    """Result of comparing expected vs stored sequences.
+
+    Used to identify exactly which transcript messages and events
+    are missing from a backend, enabling surgical re-upload
+    instead of full re-sync.
+    """
+
+    transcript_stored_count: int
+    transcript_missing_sequences: list[int]
+    event_stored_count: int
+    event_missing_sequences: list[int]
+
+
+@dataclass
 class EmbeddingOperationResult:
     """Result of a backfill or rebuild embedding operation.
 
@@ -781,6 +796,34 @@ class StorageAdmin(_StorageLifecycle):
 
         Returns:
             EmbeddingOperationResult with counts and any errors
+        """
+        ...
+
+    @abstractmethod
+    async def get_stored_transcript_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored transcript document IDs for a session.
+
+        Lightweight query -- fetches only the id field, no content.
+        IDs follow the format: {session_id}_msg_{sequence}
+        """
+        ...
+
+    @abstractmethod
+    async def get_stored_event_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored event document IDs for a session.
+
+        Lightweight query -- fetches only the id field, no content.
+        IDs follow the format: {session_id}_evt_{sequence}
         """
         ...
 

--- a/amplifier_session_storage/backends/duckdb.py
+++ b/amplifier_session_storage/backends/duckdb.py
@@ -2256,6 +2256,50 @@ class DuckDBBackend(EmbeddingMixin, StorageBackend):
 
         return await asyncio.to_thread(_query)
 
+    async def get_stored_transcript_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored transcript document IDs for a session."""
+
+        def _query() -> list[str]:
+            if self.conn is None:
+                raise StorageIOError(
+                    "get_stored_transcript_ids",
+                    cause=RuntimeError("Not initialized"),
+                )
+            rows = self.conn.execute(
+                "SELECT id FROM transcripts WHERE user_id = ? AND session_id = ?",
+                [user_id, session_id],
+            ).fetchall()
+            return [row[0] for row in rows]
+
+        return await asyncio.to_thread(_query)
+
+    async def get_stored_event_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored event document IDs for a session."""
+
+        def _query() -> list[str]:
+            if self.conn is None:
+                raise StorageIOError(
+                    "get_stored_event_ids",
+                    cause=RuntimeError("Not initialized"),
+                )
+            rows = self.conn.execute(
+                "SELECT id FROM events WHERE user_id = ? AND session_id = ?",
+                [user_id, session_id],
+            ).fetchall()
+            return [row[0] for row in rows]
+
+        return await asyncio.to_thread(_query)
+
     # =========================================================================
     # Discovery APIs
     # =========================================================================

--- a/amplifier_session_storage/backends/sqlite.py
+++ b/amplifier_session_storage/backends/sqlite.py
@@ -2134,6 +2134,44 @@ class SQLiteBackend(EmbeddingMixin, StorageBackend):
             transcript_ts_range=(transcript_earliest, transcript_latest),
         )
 
+    async def get_stored_transcript_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored transcript document IDs for a session."""
+        if self.conn is None:
+            raise StorageIOError(
+                "get_stored_transcript_ids",
+                cause=RuntimeError("Not initialized"),
+            )
+        async with self.conn.execute(
+            "SELECT id FROM transcripts WHERE user_id = ? AND session_id = ?",
+            (user_id, session_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [row[0] for row in rows]
+
+    async def get_stored_event_ids(
+        self,
+        user_id: str,
+        project_slug: str,
+        session_id: str,
+    ) -> list[str]:
+        """Return all stored event document IDs for a session."""
+        if self.conn is None:
+            raise StorageIOError(
+                "get_stored_event_ids",
+                cause=RuntimeError("Not initialized"),
+            )
+        async with self.conn.execute(
+            "SELECT id FROM events WHERE user_id = ? AND session_id = ?",
+            (user_id, session_id),
+        ) as cursor:
+            rows = await cursor.fetchall()
+        return [row[0] for row in rows]
+
     # =========================================================================
     # Discovery APIs
     # =========================================================================

--- a/amplifier_session_storage/id_utils.py
+++ b/amplifier_session_storage/id_utils.py
@@ -1,0 +1,48 @@
+"""ID generation and parsing utilities for session storage.
+
+Centralizes the ID format knowledge so callers never need to
+construct or parse document IDs directly.
+
+Transcript IDs: {session_id}_msg_{sequence}
+Event IDs: {session_id}_evt_{sequence}
+
+Sequences are 1-indexed, matching line numbers in the source JSONL files.
+"""
+
+
+def transcript_id(session_id: str, sequence: int) -> str:
+    """Generate a transcript document ID."""
+    return f"{session_id}_msg_{sequence}"
+
+
+def event_id(session_id: str, sequence: int) -> str:
+    """Generate an event document ID."""
+    return f"{session_id}_evt_{sequence}"
+
+
+def parse_transcript_sequence(doc_id: str) -> int:
+    """Extract the sequence number from a transcript document ID.
+
+    Raises ValueError on malformed input.
+    """
+    try:
+        parts = doc_id.rsplit("_msg_", 1)
+        if len(parts) != 2 or not parts[1]:
+            raise ValueError
+        return int(parts[1])
+    except (ValueError, IndexError):
+        raise ValueError(f"Malformed transcript ID: {doc_id}") from None
+
+
+def parse_event_sequence(doc_id: str) -> int:
+    """Extract the sequence number from an event document ID.
+
+    Raises ValueError on malformed input.
+    """
+    try:
+        parts = doc_id.rsplit("_evt_", 1)
+        if len(parts) != 2 or not parts[1]:
+            raise ValueError
+        return int(parts[1])
+    except (ValueError, IndexError):
+        raise ValueError(f"Malformed event ID: {doc_id}") from None

--- a/amplifier_session_storage/id_utils.py
+++ b/amplifier_session_storage/id_utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 """ID generation and parsing utilities for session storage.
 
 Centralizes the ID format knowledge so callers never need to
@@ -11,12 +9,14 @@ Event IDs: {session_id}_evt_{sequence}
 Sequences are 1-indexed, matching line numbers in the source JSONL files.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
+
+from amplifier_session_storage.backends.base import SyncGapResult
 
 if TYPE_CHECKING:
     from amplifier_session_storage.backends.base import StorageAdmin
-
-from amplifier_session_storage.backends.base import SyncGapResult
 
 
 def transcript_id(session_id: str, sequence: int) -> str:
@@ -87,31 +87,25 @@ async def find_missing_sequences(
 
     if transcript_line_count is not None:
         stored_ids = await backend.get_stored_transcript_ids(
-            user_id, project_slug, session_id,
+            user_id,
+            project_slug,
+            session_id,
         )
         transcript_stored_count = len(stored_ids)
-        expected = {
-            transcript_id(session_id, seq)
-            for seq in range(1, transcript_line_count + 1)
-        }
+        expected = {transcript_id(session_id, seq) for seq in range(1, transcript_line_count + 1)}
         missing_ids = expected - set(stored_ids)
-        transcript_missing = sorted(
-            parse_transcript_sequence(mid) for mid in missing_ids
-        )
+        transcript_missing = sorted(parse_transcript_sequence(mid) for mid in missing_ids)
 
     if event_line_count is not None:
         stored_ids = await backend.get_stored_event_ids(
-            user_id, project_slug, session_id,
+            user_id,
+            project_slug,
+            session_id,
         )
         event_stored_count = len(stored_ids)
-        expected = {
-            event_id(session_id, seq)
-            for seq in range(1, event_line_count + 1)
-        }
+        expected = {event_id(session_id, seq) for seq in range(1, event_line_count + 1)}
         missing_ids = expected - set(stored_ids)
-        event_missing = sorted(
-            parse_event_sequence(mid) for mid in missing_ids
-        )
+        event_missing = sorted(parse_event_sequence(mid) for mid in missing_ids)
 
     return SyncGapResult(
         transcript_stored_count=transcript_stored_count,

--- a/amplifier_session_storage/id_utils.py
+++ b/amplifier_session_storage/id_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """ID generation and parsing utilities for session storage.
 
 Centralizes the ID format knowledge so callers never need to
@@ -8,6 +10,13 @@ Event IDs: {session_id}_evt_{sequence}
 
 Sequences are 1-indexed, matching line numbers in the source JSONL files.
 """
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from amplifier_session_storage.backends.base import StorageAdmin
+
+from amplifier_session_storage.backends.base import SyncGapResult
 
 
 def transcript_id(session_id: str, sequence: int) -> str:
@@ -46,3 +55,67 @@ def parse_event_sequence(doc_id: str) -> int:
         return int(parts[1])
     except (ValueError, IndexError):
         raise ValueError(f"Malformed event ID: {doc_id}") from None
+
+
+async def find_missing_sequences(
+    backend: StorageAdmin,
+    user_id: str,
+    project_slug: str,
+    session_id: str,
+    transcript_line_count: int | None = None,
+    event_line_count: int | None = None,
+) -> SyncGapResult:
+    """Compare expected sequences against stored IDs, return gaps.
+
+    Args:
+        backend: Any StorageAdmin implementation.
+        user_id: User identifier.
+        project_slug: Project slug.
+        session_id: Session identifier.
+        transcript_line_count: Number of lines in local transcript.jsonl (1-indexed).
+            If None, transcript comparison is skipped.
+        event_line_count: Number of lines in local events.jsonl (1-indexed).
+            If None, event comparison is skipped.
+
+    Returns:
+        SyncGapResult with stored counts and missing sequence numbers.
+    """
+    transcript_stored_count = 0
+    transcript_missing: list[int] = []
+    event_stored_count = 0
+    event_missing: list[int] = []
+
+    if transcript_line_count is not None:
+        stored_ids = await backend.get_stored_transcript_ids(
+            user_id, project_slug, session_id,
+        )
+        transcript_stored_count = len(stored_ids)
+        expected = {
+            transcript_id(session_id, seq)
+            for seq in range(1, transcript_line_count + 1)
+        }
+        missing_ids = expected - set(stored_ids)
+        transcript_missing = sorted(
+            parse_transcript_sequence(mid) for mid in missing_ids
+        )
+
+    if event_line_count is not None:
+        stored_ids = await backend.get_stored_event_ids(
+            user_id, project_slug, session_id,
+        )
+        event_stored_count = len(stored_ids)
+        expected = {
+            event_id(session_id, seq)
+            for seq in range(1, event_line_count + 1)
+        }
+        missing_ids = expected - set(stored_ids)
+        event_missing = sorted(
+            parse_event_sequence(mid) for mid in missing_ids
+        )
+
+    return SyncGapResult(
+        transcript_stored_count=transcript_stored_count,
+        transcript_missing_sequences=transcript_missing,
+        event_stored_count=event_stored_count,
+        event_missing_sequences=event_missing,
+    )

--- a/tests/test_id_utils.py
+++ b/tests/test_id_utils.py
@@ -132,3 +132,23 @@ class TestFindMissingSequences:
         assert result.transcript_missing_sequences == []
         assert result.transcript_stored_count == 0
         backend.get_stored_transcript_ids.assert_not_called()
+
+
+class TestPublicExports:
+    def test_sync_gap_result_importable(self):
+        from amplifier_session_storage import SyncGapResult
+        assert SyncGapResult is not None
+
+    def test_id_utils_importable(self):
+        from amplifier_session_storage import (
+            transcript_id,
+            event_id,
+            parse_transcript_sequence,
+            parse_event_sequence,
+            find_missing_sequences,
+        )
+        assert callable(transcript_id)
+        assert callable(event_id)
+        assert callable(parse_transcript_sequence)
+        assert callable(parse_event_sequence)
+        assert callable(find_missing_sequences)

--- a/tests/test_id_utils.py
+++ b/tests/test_id_utils.py
@@ -1,0 +1,49 @@
+import pytest
+
+from amplifier_session_storage.id_utils import (
+    event_id,
+    parse_event_sequence,
+    parse_transcript_sequence,
+    transcript_id,
+)
+
+
+class TestTranscriptId:
+    def test_basic(self):
+        assert transcript_id("abc123", 1) == "abc123_msg_1"
+
+    def test_large_sequence(self):
+        assert transcript_id("abc123", 500) == "abc123_msg_500"
+
+
+class TestEventId:
+    def test_basic(self):
+        assert event_id("abc123", 1) == "abc123_evt_1"
+
+    def test_large_sequence(self):
+        assert event_id("abc123", 500) == "abc123_evt_500"
+
+
+class TestParseTranscriptSequence:
+    def test_basic(self):
+        assert parse_transcript_sequence("abc123_msg_42") == 42
+
+    def test_complex_session_id(self):
+        assert parse_transcript_sequence("abc-123-def_msg_1") == 1
+
+    def test_malformed_raises(self):
+        with pytest.raises(ValueError):
+            parse_transcript_sequence("not_a_valid_id")
+
+    def test_missing_sequence_raises(self):
+        with pytest.raises(ValueError):
+            parse_transcript_sequence("abc123_msg_")
+
+
+class TestParseEventSequence:
+    def test_basic(self):
+        assert parse_event_sequence("abc123_evt_42") == 42
+
+    def test_malformed_raises(self):
+        with pytest.raises(ValueError):
+            parse_event_sequence("not_a_valid_id")

--- a/tests/test_protocol_split.py
+++ b/tests/test_protocol_split.py
@@ -112,15 +112,21 @@ class TestMethodDistribution:
 
     def test_admin_methods(self) -> None:
         methods = self._abstract_methods(StorageAdmin)
-        assert methods == {"delete_session", "backfill_embeddings", "rebuild_vectors"}
+        assert methods == {
+            "delete_session",
+            "backfill_embeddings",
+            "rebuild_vectors",
+            "get_stored_transcript_ids",
+            "get_stored_event_ids",
+        }
 
     def test_storage_backend_adds_no_new_methods(self) -> None:
         methods = self._abstract_methods(StorageBackend)
         assert methods == set()
 
     def test_total_abstract_method_count(self) -> None:
-        """25 abstract methods total across the hierarchy."""
+        """27 abstract methods total across the hierarchy."""
         all_abstract = set()
         for cls in (_StorageLifecycle, StorageReader, StorageWriter, StorageAdmin):
             all_abstract |= self._abstract_methods(cls)
-        assert len(all_abstract) == 25
+        assert len(all_abstract) == 27

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -1094,3 +1094,71 @@ class TestSQLiteBackfillRebuild:
         assert result.transcripts_found == 0
         assert result.vectors_stored == 0
         assert result.vectors_failed == 0
+
+
+class TestSQLiteStoredIds:
+    """Tests for get_stored_transcript_ids and get_stored_event_ids."""
+
+    @pytest.mark.asyncio
+    async def test_empty_session_transcript(self, sqlite_storage_no_embeddings):
+        ids = await sqlite_storage_no_embeddings.get_stored_transcript_ids(
+            "user1", "proj1", "nonexistent"
+        )
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_empty_session_events(self, sqlite_storage_no_embeddings):
+        ids = await sqlite_storage_no_embeddings.get_stored_event_ids(
+            "user1", "proj1", "nonexistent"
+        )
+        assert ids == []
+
+    @pytest.mark.asyncio
+    async def test_transcript_ids_after_sync(self, sqlite_storage_no_embeddings):
+        lines = [
+            {"role": "user", "content": "hello", "ts": "2025-01-01T00:00:00Z"},
+            {"role": "assistant", "content": "hi", "ts": "2025-01-01T00:00:01Z"},
+        ]
+        await sqlite_storage_no_embeddings.sync_transcript_lines(
+            "user1", "host1", "proj1", "sess1", lines, start_sequence=1
+        )
+        ids = await sqlite_storage_no_embeddings.get_stored_transcript_ids(
+            "user1", "proj1", "sess1"
+        )
+        assert sorted(ids) == ["sess1_msg_1", "sess1_msg_2"]
+
+    @pytest.mark.asyncio
+    async def test_event_ids_after_sync(self, sqlite_storage_no_embeddings):
+        events = [
+            {"ts": "2025-01-01T00:00:00Z", "lvl": "INFO", "event": "session:start", "session_id": "sess1"},
+            {"ts": "2025-01-01T00:00:01Z", "lvl": "INFO", "event": "llm:request", "session_id": "sess1"},
+        ]
+        await sqlite_storage_no_embeddings.sync_event_lines(
+            "user1", "host1", "proj1", "sess1", events, start_sequence=1
+        )
+        ids = await sqlite_storage_no_embeddings.get_stored_event_ids(
+            "user1", "proj1", "sess1"
+        )
+        assert sorted(ids) == ["sess1_evt_1", "sess1_evt_2"]
+
+    @pytest.mark.asyncio
+    async def test_session_isolation(self, sqlite_storage_no_embeddings):
+        lines1 = [{"role": "user", "content": "a", "ts": "2025-01-01T00:00:00Z"}]
+        lines2 = [
+            {"role": "user", "content": "b", "ts": "2025-01-01T00:00:00Z"},
+            {"role": "assistant", "content": "c", "ts": "2025-01-01T00:00:01Z"},
+        ]
+        await sqlite_storage_no_embeddings.sync_transcript_lines(
+            "user1", "host1", "proj1", "sess1", lines1, start_sequence=1
+        )
+        await sqlite_storage_no_embeddings.sync_transcript_lines(
+            "user1", "host1", "proj1", "sess2", lines2, start_sequence=1
+        )
+        ids1 = await sqlite_storage_no_embeddings.get_stored_transcript_ids(
+            "user1", "proj1", "sess1"
+        )
+        ids2 = await sqlite_storage_no_embeddings.get_stored_transcript_ids(
+            "user1", "proj1", "sess2"
+        )
+        assert len(ids1) == 1
+        assert len(ids2) == 2


### PR DESCRIPTION
## Summary

Adds the ability to identify exactly which transcript messages and events are missing from a storage backend, enabling **surgical re-upload** instead of full re-sync when gaps are detected.

## Problem

The sync daemon currently detects out-of-sync situations using only aggregate counts (`SessionSyncStats`). When a gap is found, it forces a **full re-upload** of all data. For large sessions (500+ messages), this is wasteful and slow.

## Solution

New API surface that lets callers:
1. Query which document IDs a backend has stored
2. Compare against expected sequences (from local file line counts)
3. Get back exactly which sequences are missing

### New Public API

| Symbol | Purpose |
|--------|---------|
| `SyncGapResult` | Dataclass with stored counts + missing sequence lists |
| `transcript_id(session_id, seq)` | Generate transcript document ID |
| `event_id(session_id, seq)` | Generate event document ID |
| `parse_transcript_sequence(id)` | Extract sequence from transcript ID |
| `parse_event_sequence(id)` | Extract sequence from event ID |
| `find_missing_sequences(backend, ...)` | Compare expected vs stored, return gaps |

### New Abstract Methods on `StorageAdmin`

- `get_stored_transcript_ids(user_id, project_slug, session_id) -> list[str]`
- `get_stored_event_ids(user_id, project_slug, session_id) -> list[str]`

Implemented on all three backends (Cosmos DB, DuckDB, SQLite).

## Usage

```python
from amplifier_session_storage import find_missing_sequences

result = await find_missing_sequences(
    backend=storage,
    user_id="user1",
    project_slug="proj1",
    session_id="sess1",
    transcript_line_count=50,   # caller knows this from local file
    event_line_count=120,
)

# result.missing_transcript_sequences -> [12, 43, 44]
# result.missing_event_sequences -> [88, 89]
```

## Integration

This is the storage library side of a larger sync improvement. The server/daemon integration is tracked at:
- https://github.com/microsoft/amplifier-session-sync/issues/13

Design document: `docs/DESIGN-sync-gap-detection.md`

## Testing

- 19 new unit tests for utilities and `find_missing_sequences` (mock-based)
- 5 new DuckDB backend tests (in-memory)
- 5 new SQLite backend tests (in-memory)
- 3 new Cosmos integration tests (env-based, skip gracefully)
- Full suite: **258 passed, 3 skipped, 0 failures**

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>